### PR TITLE
fix: disable autoloading in typeIsValid to prevent fatal errors during generation

### DIFF
--- a/src/Element/TypeHintedElementTrait.php
+++ b/src/Element/TypeHintedElementTrait.php
@@ -34,7 +34,7 @@ trait TypeHintedElementTrait
         return
             is_null($type)
             || $type instanceof PhpClass
-            || (is_string($type) && class_exists($type))
+            || (is_string($type) && class_exists($type, false))
             || in_array($type, TypeHintedElementInterface::TYPES, true)
             || static::stringIsValid($type, true, true);
     }

--- a/tests/Element/PhpFunctionParameterTest.php
+++ b/tests/Element/PhpFunctionParameterTest.php
@@ -46,6 +46,11 @@ class PhpFunctionParameterTest extends TestCase
         $this->assertTrue(PhpFunctionParameter::typeIsValid('Partagé'));
     }
 
+    public function testTypeIsValidWithUnloadedFullyQualifiedClassName()
+    {
+        $this->assertTrue(PhpFunctionParameter::typeIsValid('\\Some\\Namespace\\NonExistentClass'));
+    }
+
     public function testFloatValueForDeclaration()
     {
         $initialSerializePrecision = ini_get('serialize_precision');


### PR DESCRIPTION
## Problem

`TypeHintedElementTrait::typeIsValid()` calls `class_exists($type)` which triggers the PHP autoloader by default. When used by `wsdltophp/packagegenerator` to generate code from a WSDL, this can cause **fatal errors** when a freshly-generated class file is autoloaded and its parent class hasn't been generated yet.

The call chain is: `PhpFunctionParameter::setType()` → `typeIsValid()` → `class_exists($type)` → autoloader includes the generated file → PHP tries to resolve `extends ParentType` → **fatal error** if the parent class file hasn't been written yet.

## Fix

Pass `false` as the second argument to `class_exists()` to disable autoloading:

```php
// Before
|| (is_string($type) && class_exists($type))

// After
|| (is_string($type) && class_exists($type, false))
```

This has no impact on validation effectiveness — the subsequent `stringIsValid()` check validates the type string format, and `class_exists($type, false)` still matches classes that are already loaded in memory.